### PR TITLE
upgraded nozzle to version 1.1.17

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -78,23 +78,23 @@ The following table provides version and version-support information about New R
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td>1.1.16</td>
+        <td>1.1.17</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>January 24, 2019</td>
+        <td>June 18, 2019</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>New Relic Nozzle v1.1.16</td>
+        <td>New Relic Nozzle v1.1.17</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>2.1.x, 2.2.x, 2.3.x, and 2.4.x</td>
+        <td>2.3.x, 2.4.x, 2.5.x, and 2.6.x</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service versions</td>
-        <td>2.1.x, 2.2.x, 2.3.x, and 2.4.x</td>
+        <td>2.3.x, 2.4.x, 2.5.x, and 2.6.x</td>
     </tr>
     <tr>
         <td>BOSH stemcell version</td>
@@ -115,7 +115,7 @@ If a security vulnerability is found on this stemcell after April, it will not b
 
 ## <a id='compatibility'></a> Compatibility
 
-This project has been tested and is compatible with PCF versions v1.8.x through v2.4.x.
+This project has been tested and is compatible with PCF versions v2.3.x through v2.6.x.
 
 
 ## <a id="reqs"></a> Requirements
@@ -128,7 +128,7 @@ New Relic Nozzle for PCF has the following requirements:
 
 ## <a id='trial'></a> Trial License
 
-If you do not already have a New Relic account, you can obtain a [60-day free trial license](http://newrelic.com/signup?funnel=pivotal-cloud-foundry&partner=Pivotal+Cloud+Foundry&product_id=Standard&promo_code=PVCF60PRO).
+If you do not already have a New Relic account, you can obtain a [14-day free trial license](http://newrelic.com/signup?funnel=pivotal-cloud-foundry&partner=Pivotal+Cloud+Foundry).
 
 
 ## <a id="feedback"></a> Feedback

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -82,7 +82,7 @@ The following table provides version and version-support information about New R
     </tr>
     <tr>
         <td>Release date</td>
-        <td>June 18, 2019</td>
+        <td>June 24, 2019</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -12,6 +12,7 @@ These are release notes for New Relic Nozzle for PCF.
 
 Features included in this release:
 
+* updated to BOSH Release 1.16.0 (corresponds to version 6.45.0 of the CF CLI)
 * Tested on PCF up to and including v2.6
 
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -6,7 +6,16 @@ owner: Partners
 These are release notes for New Relic Nozzle for PCF.
 
 
-## <a id="ver-1.1.15"></a> v1.1.16
+## <a id="ver-1.1.17"></a> v1.1.17
+
+**General Availability Release Date:** June 18, 2019
+
+Features included in this release:
+
+* Tested on PCF up to and including v2.6
+
+
+## <a id="ver-1.1.16"></a> v1.1.16
 
 **General Availability Release Date:** January 24, 2019
 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -8,7 +8,7 @@ These are release notes for New Relic Nozzle for PCF.
 
 ## <a id="ver-1.1.17"></a> v1.1.17
 
-**General Availability Release Date:** June 18, 2019
+**General Availability Release Date:** June 24, 2019
 
 Features included in this release:
 


### PR DESCRIPTION
nozzle 1.1.17
- updated to BOSH Release 1.16.0 (corresponds to version 6.45.0 of the CF CLI)
- Tested the tile on PCF up to and including v2.6